### PR TITLE
[bilibili] Subs downloader improvements

### DIFF
--- a/Python/008_download_and_convert_b23_subtitle.py
+++ b/Python/008_download_and_convert_b23_subtitle.py
@@ -12,6 +12,7 @@ to srt subtitle format
 
 import re
 import requests
+import datetime
 
 
 def obtain_cc_subtitle(avid: str = "77948393") -> None:
@@ -45,12 +46,32 @@ def convert_to_srt(srt_id: str, subtitles: list) -> None:
     """
     srt = []
     for index, subtitle in enumerate(subtitles):
-        srt_tmp = f"""{index}\n{subtitle["from"]} --> {subtitle["to"]}\n{subtitle["content"]}\n"""
+        from_timestamp = convert_timestamp_format(subtitle["from"])
+        to_timestamp = convert_timestamp_format(subtitle["to"])
+        srt_tmp = f"""{index}\n{from_timestamp} --> {to_timestamp}\n{subtitle["content"]}\n"""
         srt.append(srt_tmp)
 
     with open(f"{srt_id}.srt", "w", encoding="utf-8") as f:
         f.write("\n".join(srt))
 
+
+def convert_timestamp_format(cc_timestamp: float) -> str:
+    """
+    convert cc timestamp format to srt subtitles timestamp format
+
+    $cc_timestamp: a seconds format cc timestamp
+    """
+    cc_timestamp = str(cc_timestamp)
+    s = 0
+    mm = 0
+    if "." in cc_timestamp:
+        s = int(cc_timestamp.split(".")[0])
+        mm = int(cc_timestamp.split(".")[1])
+    else:
+        s = int(cc_timestamp)
+    m, s = divmod(s, 60)
+    h, m = divmod(m, 60)
+    return f'{h:02d}:{m:02d}:{s:02d},{mm:03d}'
 
 if __name__ == "__main__":
     obtain_cc_subtitle("60977932")

--- a/Python/008_download_and_convert_b23_subtitle.py
+++ b/Python/008_download_and_convert_b23_subtitle.py
@@ -12,7 +12,6 @@ to srt subtitle format
 
 import re
 import requests
-import datetime
 
 
 def obtain_cc_subtitle(vid: str = "") -> None:

--- a/Python/008_download_and_convert_b23_subtitle.py
+++ b/Python/008_download_and_convert_b23_subtitle.py
@@ -62,14 +62,9 @@ def convert_timestamp_format(cc_timestamp: float) -> str:
 
     $cc_timestamp: a seconds format cc timestamp
     """
-    cc_timestamp = str(cc_timestamp)
-    s = 0
-    mm = 0
-    if "." in cc_timestamp:
-        s = int(cc_timestamp.split(".")[0])
-        mm = int(cc_timestamp.split(".")[1])
-    else:
-        s = int(cc_timestamp)
+    s, mm = int(cc_timestamp), 0
+    if "." in str(cc_timestamp):
+        s, mm = map(int, str(cc_timestamp).split("."))
     m, s = divmod(s, 60)
     h, m = divmod(m, 60)
     return f"{h:02d}:{m:02d}:{s:02d},{mm:03d}"

--- a/Python/008_download_and_convert_b23_subtitle.py
+++ b/Python/008_download_and_convert_b23_subtitle.py
@@ -15,13 +15,13 @@ import requests
 import datetime
 
 
-def obtain_cc_subtitle(avid: str = "77948393") -> None:
+def obtain_cc_subtitle(vid: str = "") -> None:
     """
     obtain cc subtitles
 
-    $avid: id of the video
+    $vid: id of the video
     """
-    url = f"https://www.bilibili.com/video/av{avid}"
+    url = f"https://www.bilibili.com/video/{vid}"
     headers = {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 "
         "(KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
@@ -74,4 +74,4 @@ def convert_timestamp_format(cc_timestamp: float) -> str:
     return f'{h:02d}:{m:02d}:{s:02d},{mm:03d}'
 
 if __name__ == "__main__":
-    obtain_cc_subtitle("60977932")
+    obtain_cc_subtitle("av60977932")

--- a/Python/008_download_and_convert_b23_subtitle.py
+++ b/Python/008_download_and_convert_b23_subtitle.py
@@ -48,7 +48,9 @@ def convert_to_srt(srt_id: str, subtitles: list) -> None:
     for index, subtitle in enumerate(subtitles):
         from_timestamp = convert_timestamp_format(subtitle["from"])
         to_timestamp = convert_timestamp_format(subtitle["to"])
-        srt_tmp = f"""{index}\n{from_timestamp} --> {to_timestamp}\n{subtitle["content"]}\n"""
+        srt_tmp = (
+            f"""{index}\n{from_timestamp} --> {to_timestamp}\n{subtitle["content"]}\n"""
+        )
         srt.append(srt_tmp)
 
     with open(f"{srt_id}.srt", "w", encoding="utf-8") as f:
@@ -71,7 +73,8 @@ def convert_timestamp_format(cc_timestamp: float) -> str:
         s = int(cc_timestamp)
     m, s = divmod(s, 60)
     h, m = divmod(m, 60)
-    return f'{h:02d}:{m:02d}:{s:02d},{mm:03d}'
+    return f"{h:02d}:{m:02d}:{s:02d},{mm:03d}"
+
 
 if __name__ == "__main__":
     obtain_cc_subtitle("av60977932")


### PR DESCRIPTION
首先感谢你写了这个script，我是从这里看到的：https://www.bilibili.com/read/cv4311765/

---

This PR includes a couple tweaks/improvements to the script I needed to make before it worked for me. First is that the video I wanted to download subs for has a video id that doesn't start with `av`. Second is that I had trouble using the converted srt file in IINA due to the unconventionally formatted timestamp.
 
This PR:
- removes the hardcoded `av` prefix
- adds a `convert_timestamp_format` method to convert the cc timestamp in seconds format to the `srt` `hours:minutes:seconds,milliseconds` format
